### PR TITLE
Added SLP library, basic balance calls

### DIFF
--- a/Examples/SLP Rewards API.postman_collection.json
+++ b/Examples/SLP Rewards API.postman_collection.json
@@ -1,0 +1,110 @@
+{
+	"info": {
+		"_postman_id": "a4d6a198-c86c-4a23-913e-3e93bb3d69bd",
+		"name": "SLP Rewards",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Hello World",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "localhost:3000",
+					"host": [
+						"localhost"
+					],
+					"port": "3000"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Hello World POST",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"data\": \"Bar!\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/postTest",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"postTest"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Address Balance (BCH)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3000/v1/address/simpleledger:qz9rtlhjhft05zgzjryge45k99e2hrwn5vsvw8art7/balance",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"v1",
+						"address",
+						"simpleledger:qz9rtlhjhft05zgzjryge45k99e2hrwn5vsvw8art7",
+						"balance"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Address Balance (SLP)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3000/v1/address/simpleledger:qz9rtlhjhft05zgzjryge45k99e2hrwn5vsvw8art7/token/bc1f1f7288f0a91cfe6f2e6bde3a581b772657512974193dbf55a10f844e0057/balance",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"v1",
+						"address",
+						"simpleledger:qz9rtlhjhft05zgzjryge45k99e2hrwn5vsvw8art7",
+						"token",
+						"bc1f1f7288f0a91cfe6f2e6bde3a581b772657512974193dbf55a10f844e0057",
+						"balance"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/Readme.txt
+++ b/Readme.txt
@@ -3,6 +3,8 @@ Useful Info:
 NPM version used: 6.11.3
 Node version used: 8.11.1
 
+Windows: Will need python 2.7 installed for bitbox-sdk
+
 Need to install globally: npm, node, typescript, tslint, nodemon
 
 Don't forget to run "npm install". 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "Port": 3000,
-    "RestURL": "",
+    "RestURL": "https://rest.bitcoin.com/v2/",
     "TokenID": "",
     "FundingAddress": "",
     "FundingWif": ""

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "homepage": "https://github.com/SLPVH/slp-rewards#readme",
   "devDependencies": {
+    "@types/body-parser": "^1.17.1",
     "@types/express": "^4.17.1"
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "slp-sdk": "^4.11.0"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,15 @@
 // Import Node modules
 
+console.log('Starting Rewards Server...');
+
 import * as bodyParser from 'body-parser';
 
+import { GetBalanceOfBCHAddress } from './logic/requests/GetBalanceOfBCHAddress';
+import { GetTokenBalanceOfSLPAddress } from './logic/requests/GetTokenBalanceOfSLPAddress';
 import { HTTPResponse } from './models/http_responses/httpResponse';
 import { HelloWorldRequest } from './models/http_requests/helloWorldRequest';
 import { InvalidParametersError } from './models/InvalidParametersError';
+import { SLPHelper } from './logic/SLPHelper';
 import express from 'express';
 import fs from 'fs';
 
@@ -21,11 +26,26 @@ app.use(bodyParser.urlencoded({ extended: false }));
 // Parse application/json
 app.use(bodyParser.json());
 
+//Attempt to connect to Bitcoin REST API
+console.log(`Attempting to connect to Bitcoin REST API at 'config.RestURL'...`);
+try
+{
+    app.locals.SLPHelper = new SLPHelper(config.RestURL);
+    console.log('Success!');
+} catch (ex) {
+    console.error('Server cannot start, could not connect to Bitcoin REST API');
+    throw ex;
+}
+
 // Specify routes
-// Get balance of address
-app.get('/v1/:address/balance', (req, res) => {
-    console.log(req.params);
-    res.sendStatus(501);
+// Get BCH balance of address
+app.get('/v1/address/:address/balance', (req, res) => {
+    GetBalanceOfBCHAddress.Execute(req, res);
+});
+
+// Get specific SLP token balance of address
+app.get('/v1/address/:address/token/:tokenId/balance', (req, res) => {
+    GetTokenBalanceOfSLPAddress.Execute(req, res);
 });
 
 // Hello world GET and POST tests
@@ -57,5 +77,5 @@ app.listen(config.Port, (err) => {
   if (err) {
     return console.error(`Error starting server: ${err}`);
   }
-  return console.log(`server is listening on ${config.Port}`);
+  return console.log(`Server is running and listening on ${config.Port}...`);
 });

--- a/src/logic/SLPHelper.ts
+++ b/src/logic/SLPHelper.ts
@@ -1,0 +1,42 @@
+let SLPSDK = require('slp-sdk');
+
+export class SLPHelper {
+    private SLP: any;
+
+    constructor(restURL: string) {
+        this.SLP = new SLPSDK({ 
+            restURL: restURL 
+        });
+    }
+
+    async GetSLPTokenSymbol(tokenId: string) : Promise<string> {
+        try {
+            const details = await this.SLP.Utils.list(tokenId);
+            if (!details || details.id === 'not found') {
+                return Promise.reject(`The Token Id '${tokenId}' does not exist on this chain`);
+            }
+            
+            return details.symbol as string;
+        } catch(ex) {
+            return Promise.reject(ex.message);
+        }
+    } 
+
+    async GetTokenBalanceOfSLPAddress(tokenId: string, address: string) : Promise<number> {
+        try {
+            const details = await this.SLP.Utils.balance(address, tokenId);
+            return details.balance as number;
+        } catch(ex) {
+            return Promise.reject(ex.message);
+        }
+    } 
+
+    async GetBalanceOfBCHAddress(address: string) : Promise<number> {
+        try {
+            let details = await this.SLP.Address.details(`${address}`);
+            return details.balance as number;
+        } catch(ex) {
+            return Promise.reject(ex.message);
+        }
+    } 
+}

--- a/src/logic/requests/GetBalanceOfBCHAddress.ts
+++ b/src/logic/requests/GetBalanceOfBCHAddress.ts
@@ -1,0 +1,26 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+
+import { HTTPResponse } from '../../models/http_responses/httpResponse';
+import { SLPHelper } from "../SLPHelper";
+
+export class GetBalanceOfBCHAddress {
+    static Execute(req: express.Request, res: express.Response) {
+        const SLPHelper = req.app.locals.SLPHelper as SLPHelper;
+
+        if (!req.params || !req.params.address) {
+            res.status(400).json(new HTTPResponse(null, 'Address not specified'));
+            return;
+        }
+    
+        SLPHelper.GetBalanceOfBCHAddress(req.params.address)
+        .then((balance) => {
+            res.json(new HTTPResponse({
+                balance: balance
+            }));
+        })
+        .catch((err) => {
+            res.status(400).json(new HTTPResponse(null, err));
+        });
+    }
+}

--- a/src/logic/requests/GetTokenBalanceOfSLPAddress.ts
+++ b/src/logic/requests/GetTokenBalanceOfSLPAddress.ts
@@ -1,0 +1,30 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+
+import { HTTPResponse } from '../../models/http_responses/httpResponse';
+import { SLPHelper } from "../SLPHelper";
+
+export class GetTokenBalanceOfSLPAddress {
+    static Execute(req: express.Request, res: express.Response) {
+        const SLPHelper = req.app.locals.SLPHelper as SLPHelper;
+
+        if (!req.params || !req.params.address || !req.params.tokenId) {
+            res.status(400).json(new HTTPResponse(null, 'Address and/or Token Id not specified'));
+            return;
+        }
+    
+        Promise.all([
+            SLPHelper.GetTokenBalanceOfSLPAddress(req.params.tokenId, req.params.address),
+            SLPHelper.GetSLPTokenSymbol(req.params.tokenId),
+        ])
+        .then(([balance, symbol]) => {
+            res.json(new HTTPResponse({
+                balance: balance,
+                symbol: symbol
+            }));
+        })
+        .catch((err) => {
+            res.status(400).json(new HTTPResponse(null, err));
+        });
+    }
+}

--- a/src/models/http_responses/httpResponse.ts
+++ b/src/models/http_responses/httpResponse.ts
@@ -2,7 +2,7 @@ export class HTTPResponse {
     public response: object;
     public err: string;
 
-    constructor(data: object, err: string) {
+    constructor(data: object, err: string = null) {
         this.response = data;
         this.err = err;
     }


### PR DESCRIPTION
Added SLP library, can now execute 2 GET requests, to get a balance of BCH and a balance of a specific token for an address. Postman examples added